### PR TITLE
Model display options added

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,29 @@ Embed STL render using Viewstl.com excellent library v1.13
 
 Options are URL encoded a=1&b=2 etc
 
-- manual: Do not render automatically, show a link to trigger it
-- noop: disable rendering (link instead)
-- s: size in pixel (defines height and width in one call)
-- h: height in pixel
-- w: width in pixel
-- color: color of the object
-- bgcolor: background color
+- manual: Do not render automatically
+  - Example: ``manual=true`` to show a link that triggers the loading of the model
+- noop: Disable rendering
+  - Example: ``noop=true`` to show only a link of the .stl file
+- s: Size in pixel (defines height and width in one call)
+  - Example: ``s=400`` for a frame 400 x 400 pixels
+- h: Height in pixel
+  - Example: ``h=400`` for a height of 400 pixels
+- w: Width in pixel
+  - Example: ``w=400`` for a width of 400 pixels
+- color: Color of the model
+  - Example: ``color=#00ff00`` for a green model
+- bgcolor: Background color
+  - Example: ``color=#ffffff`` for a white background
+- display: Set model display/shading ("flat", "smooth" or "wireframe")
+  - Example: ``model=wireframe``
 
+Example for a complete syntax: ``{{my_model.stl?h=400&w=600&bgcolor=#cccccc&color=#eb984e&display=wireframe&noop=true|My model title}}``
 
 ## Changelog
 
+* **2025-03-20**
+  * model display options added (@Ragos81)
 * **2024-04-09**
   * fix background color (@Ragos81)
 * **2022-09-07**

--- a/syntax.php
+++ b/syntax.php
@@ -11,6 +11,7 @@
  *  - w: width in pixel
  *  - color: color of the object
  *  - bgcolor: background color
+ *  - display: Model shading to display (String: "flat" / "smooth"/ "wireframe", Default: "flat")
  *
  */
 
@@ -50,6 +51,7 @@ class syntax_plugin_stlviewer extends DokuWiki_Syntax_Plugin {
                        'height'  => '500px',
                        'bgcolor' => '#aaaaaa',
                        'color'   => '#be5050',
+                       'display' => 'flat',
         );
 
         $cleanmatch = trim($match, '{}');
@@ -79,15 +81,16 @@ class syntax_plugin_stlviewer extends DokuWiki_Syntax_Plugin {
         if (isset($pargs['w'])) {
             $opts['width'] = $pargs['w'];
         }
-
         if (isset($pargs['noop'])) {
             $opts['noop'] = true;
         }
-
         if (isset($pargs['manual'])) {
             $opts['manual'] = true;
         }
-
+        if (isset($pargs['display'])) {
+            $opts['display'] = $pargs['display'];
+        }
+        
         foreach (['bgcolor', 'color'] as $k) {
             if (isset($pargs[$k]) && $pargs[$k] != "") {
                 $opts[$k] = $pargs[$k];
@@ -151,6 +154,7 @@ class syntax_plugin_stlviewer extends DokuWiki_Syntax_Plugin {
         $buff[] = "      models: [ {";
         $buff[] = "        id:0,";
         $buff[] = "        color: \"".$opts['color']."\",";
+        $buff[] = "        display: \"".$opts['display']."\",";
         $buff[] = "        filename: \"" . $mediaurl . "\"";
         $buff[] = "      } ]";
         $buff[] = "    }";


### PR DESCRIPTION
Not the model shading can be changed to "flat", "smooth" or just show a "wireframe".
Syntax: ``display=wireframe``